### PR TITLE
Add accordion expand to projects, remove YouTube

### DIFF
--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -25,25 +25,23 @@
   flex-direction: column;
 }
 
+/* --- Row --- */
 .project-row {
-  display: grid;
-  grid-template-columns: 4rem 1fr auto;
-  align-items: center;
-  gap: 2vw;
-  padding: 2.5vw 0;
   border-bottom: 1px solid var(--border);
-  transition: color 0.3s ease, opacity 0.3s ease;
+  padding: 2.5vw 0;
+  cursor: pointer;
+  transition: padding 0.3s ease, opacity 0.3s ease;
 }
 
 .project-row:last-child {
   border-bottom: none;
 }
 
-.project-row:hover {
-  color: var(--text-bright);
+.project-row:hover:not(.expanded) {
+  padding: 3.2vw 0;
 }
 
-.project-row:hover .project-name {
+.project-row:hover:not(.expanded) .project-name {
   color: var(--text-bright);
 }
 
@@ -51,6 +49,78 @@
   opacity: 0.3;
 }
 
+/* --- Row header (original grid layout) --- */
+.project-row-header {
+  display: grid;
+  grid-template-columns: 4rem 1fr auto;
+  align-items: center;
+  gap: 2vw;
+}
+
+/* --- Accordion expanded content --- */
+.project-expanded-content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.5s ease;
+}
+
+.project-row.expanded .project-expanded-content {
+  grid-template-rows: 1fr;
+}
+
+.project-expanded-content > * {
+  overflow: hidden;
+}
+
+.project-expanded-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding-top: 0;
+  opacity: 0;
+  transition: opacity 0.3s ease, padding-top 0.3s ease;
+}
+
+.project-row.expanded .project-expanded-inner {
+  padding-top: 2rem;
+  opacity: 1;
+  transition: opacity 0.3s ease 0.2s, padding-top 0.3s ease;
+}
+
+.project-expanded-desc {
+  font-size: clamp(0.85rem, 1.4vw, 1.1rem);
+  line-height: 1.7;
+  color: var(--text);
+  max-width: 700px;
+}
+
+.project-expanded-screenshot {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.project-expanded-screenshot img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.project-screenshot-placeholder {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  opacity: 0.4;
+  font-size: clamp(0.7rem, 1.2vw, 0.9rem);
+  text-transform: uppercase;
+}
+
+/* --- Existing element styles --- */
 .project-index {
   font-size: clamp(0.7rem, 1vw, 0.85rem);
   color: var(--accent);
@@ -123,10 +193,17 @@
 }
 
 @media (max-width: 600px) {
-  .project-row {
+  .project-row-header {
     grid-template-columns: 2.5rem 1fr;
     gap: 3vw;
+  }
+
+  .project-row {
     padding: 5vw 0;
+  }
+
+  .project-row:hover:not(.expanded) {
+    padding: 6vw 0;
   }
 
   .project-links {

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -9,6 +9,8 @@ const projects = [
     github: 'https://github.com/paintedlabs/Treachery-FrontEnd',
     liveUrl: 'https://treachery.games',
     liveLabel: 'Play',
+    longDescription: 'A multiplayer Magic: The Gathering variant app for iOS that brings the Treachery format to your phone. Play with friends in real-time with role-based gameplay.',
+    screenshot: null, // TODO: add screenshot path e.g. '/screenshots/treachery.png'
   },
   {
     name: 'The Lazer Dragon Workout Experience',
@@ -17,6 +19,8 @@ const projects = [
     github: 'https://github.com/nsluke/Lazer-Dragon-Workout-Experience',
     liveUrl: 'https://testflight.apple.com/join/Uv2Xufqr',
     liveLabel: 'TestFlight',
+    longDescription: 'An iOS workout app disguised as a boss battle. Complete exercises to deal damage to the Lazer Dragon — skip reps and face the consequences.',
+    screenshot: null,
   },
   {
     name: 'Claudius',
@@ -25,6 +29,8 @@ const projects = [
     github: 'https://github.com/nsluke/Claudius',
     liveUrl: 'https://github.com/nsluke/Claudius/releases',
     liveLabel: 'Download',
+    longDescription: 'A macOS menu bar app that tracks your Claude API usage in real-time. See spend, token counts, and usage trends at a glance without leaving your workflow.',
+    screenshot: null,
   },
   {
     name: 'Manadrain',
@@ -33,12 +39,16 @@ const projects = [
     github: 'https://github.com/nsluke/manadrain',
     liveUrl: 'https://addons.mozilla.org/en-US/firefox/addon/manadrain-mtg-shopping-list/',
     liveLabel: 'Firefox Add-on',
+    longDescription: 'A Firefox browser extension that lets you save Magic: The Gathering cards to a shopping list while browsing. Quickly stash cards you want to buy later.',
+    screenshot: null,
   },
   {
     name: 'Planechase Bot',
     description: 'Discord bot for playing Planechase',
     tech: 'Python',
     github: 'https://github.com/nsluke/Planechase-Bot',
+    longDescription: 'A Discord bot that manages Planechase games for Magic: The Gathering. Handles plane cards, dice rolls, and game state so your group can play Planechase remotely.',
+    screenshot: null,
   },
   {
     name: 'PushPush',
@@ -47,12 +57,16 @@ const projects = [
     github: 'https://github.com/nsluke/PushPush',
     liveUrl: 'https://testflight.apple.com/join/wRBak44b',
     liveLabel: 'TestFlight',
+    longDescription: 'The very first iOS game I ever built. A simple but addictive pushing game written in Objective-C. Still holds up after all these years.',
+    screenshot: null,
   },
   {
     name: 'Mock Starket',
     description: 'Buy REAL fake stocks and lose real fake money',
     tech: 'Swift',
     github: 'https://github.com/nsluke/Mock-Starket-iOS',
+    longDescription: 'A mock stock trading app for iOS. Practice trading with fake money and real-ish market data. Perfect for learning without the financial consequences.',
+    screenshot: null,
   },
   {
     name: 'Bling My Deck',
@@ -61,11 +75,18 @@ const projects = [
     github: 'https://github.com/nsluke/blingmydeck',
     liveUrl: 'https://blingoutmydeck.com',
     liveLabel: 'Visit',
+    longDescription: 'A web tool that finds the most expensive printing of every card in your Magic: The Gathering deck. Paste your decklist and see just how much it would cost to fully bling it out.',
+    screenshot: null,
   },
 ]
 
 function Projects() {
   const [hovered, setHovered] = useState(null)
+  const [selected, setSelected] = useState(null)
+
+  const toggleProject = (i) => {
+    setSelected(selected === i ? null : i)
+  }
 
   return (
     <section className="projects" id="projects">
@@ -74,45 +95,75 @@ function Projects() {
         <span className="project-count">{projects.length} Projects</span>
       </div>
       <div className="projects-list">
-        {projects.map((project, i) => (
-          <div
-            key={project.name}
-            className={`project-row ${hovered !== null && hovered !== i ? 'dimmed' : ''}`}
-            onMouseEnter={() => setHovered(i)}
-            onMouseLeave={() => setHovered(null)}
-          >
-            <div className="project-index">
-              {String(i + 1).padStart(2, '0')}
+        {projects.map((project, i) => {
+          const isOpen = selected === i
+
+          return (
+            <div
+              key={project.name}
+              className={[
+                'project-row',
+                hovered !== null && hovered !== i && selected === null ? 'dimmed' : '',
+                isOpen ? 'expanded' : '',
+              ].filter(Boolean).join(' ')}
+              onMouseEnter={() => selected === null && setHovered(i)}
+              onMouseLeave={() => setHovered(null)}
+              onClick={() => toggleProject(i)}
+            >
+              <div className="project-row-header">
+                <div className="project-index">
+                  {String(i + 1).padStart(2, '0')}
+                </div>
+                <div className="project-info">
+                  <h3 className="project-name">{project.name}</h3>
+                  <p className="project-desc">{project.description}</p>
+                  <span className="project-tech">{project.tech}</span>
+                </div>
+                <div className="project-links">
+                  <a
+                    href={project.github}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="project-link"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    GitHub
+                  </a>
+                  {project.liveUrl ? (
+                    <a
+                      href={project.liveUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="project-link project-link-live"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {project.liveLabel} -&gt;
+                    </a>
+                  ) : (
+                    <span className="project-link project-link-soon">Coming Soon</span>
+                  )}
+                </div>
+              </div>
+
+              <div className="project-expanded-content">
+                <div className="project-expanded-inner">
+                  <p className="project-expanded-desc">
+                    {project.longDescription || project.description}
+                  </p>
+                  <div className="project-expanded-screenshot">
+                    {project.screenshot ? (
+                      <img src={project.screenshot} alt={`${project.name} screenshot`} />
+                    ) : (
+                      <div className="project-screenshot-placeholder">
+                        <span>Screenshot Coming Soon</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
             </div>
-            <div className="project-info">
-              <h3 className="project-name">{project.name}</h3>
-              <p className="project-desc">{project.description}</p>
-              <span className="project-tech">{project.tech}</span>
-            </div>
-            <div className="project-links">
-              <a
-                href={project.github}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="project-link"
-              >
-                GitHub
-              </a>
-              {project.liveUrl ? (
-                <a
-                  href={project.liveUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="project-link project-link-live"
-                >
-                  {project.liveLabel} -&gt;
-                </a>
-              ) : (
-                <span className="project-link project-link-soon">Coming Soon</span>
-              )}
-            </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </section>
   )

--- a/src/components/Socials.jsx
+++ b/src/components/Socials.jsx
@@ -2,7 +2,6 @@ import './Socials.css'
 
 const links = [
   { name: 'GitHub', url: 'https://github.com/nsluke' },
-  { name: 'YouTube', url: 'https://www.youtube.com/@LukeSS' },
   { name: 'Instagram', url: 'https://www.instagram.com/luke_solomon/' },
   { name: 'X / Twitter', url: 'https://twitter.com/_luke_warm' },
   { name: 'LinkedIn', url: 'https://www.linkedin.com/in/luke-solomon-7b846375/' },


### PR DESCRIPTION
## Summary
- **Accordion project rows**: Clicking a project row expands it in-place to reveal a longer description and screenshot placeholder (uses `grid-template-rows` for smooth animation)
- **Hover hint**: Rows grow slightly on hover to signal they're clickable
- **Remove YouTube**: Removed YouTube link from the Connect section

## Test plan
- [x] Verify hover effect on project rows (slight padding increase)
- [x] Click a project row — confirm it expands smoothly in-place
- [x] Click again or click another row — confirm it collapses
- [x] Verify GitHub/live links still work without triggering the accordion
- [x] Check mobile responsiveness
- [x] Confirm YouTube is no longer in Connect section

🤖 Generated with [Claude Code](https://claude.com/claude-code)