### PR TITLE
Constrain accordion screenshot dimensions

### DIFF
--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -105,7 +105,7 @@
 
 .project-expanded-screenshot img {
   max-width: 100%;
-  max-height: 400px;
+  max-height: 100px;
   width: auto;
   height: auto;
   display: block;
@@ -114,7 +114,7 @@
 
 .project-screenshot-placeholder {
   width: 100vw;
-  max-width: 600px;
+  max-width: 100px;
   aspect-ratio: 16 / 9;
   display: flex;
   align-items: center;

--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -95,20 +95,26 @@
 }
 
 .project-expanded-screenshot {
-  width: 100%;
+  width: fit-content;
+  max-width: 100%;
   border: 1px solid var(--border);
   border-radius: 4px;
   overflow: hidden;
+  margin-top: 1.5rem;
 }
 
 .project-expanded-screenshot img {
-  width: 100%;
+  max-width: 100%;
+  max-height: 400px;
+  width: auto;
   height: auto;
   display: block;
+  object-fit: contain;
 }
 
 .project-screenshot-placeholder {
-  width: 100%;
+  width: 100vw;
+  max-width: 600px;
   aspect-ratio: 16 / 9;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Cap screenshot height at 100px in the project accordion so wide-aspect screenshots don't push the row layout
- Constrain placeholder block to match

## Test plan
- [ ] Expand each project row on desktop and confirm screenshots render at the new max size
- [ ] Verify the "Screenshot Coming Soon" placeholder for Planechase Bot still looks correct
- [ ] Spot-check on mobile width

🤖 Generated with [Claude Code](https://claude.com/claude-code)