### PR TITLE
Fix malformed mailto link in Socials

### DIFF
--- a/src/components/Socials.jsx
+++ b/src/components/Socials.jsx
@@ -5,7 +5,7 @@ const links = [
   { name: 'Instagram', url: 'https://www.instagram.com/luke_solomon/' },
   { name: 'X / Twitter', url: 'https://twitter.com/_luke_warm' },
   { name: 'LinkedIn', url: 'https://www.linkedin.com/in/luke-solomon-7b846375/' },
-  { name: 'Email', url: 'mailto:solomora@gmail.com+portfolio' },
+  { name: 'Email', url: 'mailto:solomora+portfolio@gmail.com' },
   { name: 'MySpace', url: '/myspace/' },
 ]
 


### PR DESCRIPTION
## Summary
- The Email tile pointed at \`mailto:solomora@gmail.com+portfolio\` — \`+portfolio\` was tacked on after the domain, making it invalid
- Moves the tag inside the local part: \`mailto:solomora+portfolio@gmail.com\` (Gmail plus-addressing)

Closes #8

## Test plan
- [ ] Click the Email tile in the Connect section and confirm the mail client opens with \`solomora+portfolio@gmail.com\` as the To: address

🤖 Generated with [Claude Code](https://claude.com/claude-code)