### PR TITLE
Remove orphan slash in hero meta line

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -7,8 +7,6 @@ function Hero() {
         <h1 className="hero-name">Luke Solomon</h1>
         <p className="hero-tagline">Made In New York.</p>
         <div className="hero-meta">
-          <span></span>
-          <span className="hero-sep">/</span>
           <span>iOS, Web, Godot.</span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The empty \`<span>\` left over after \"New York\" moved to the tagline produced a leading slash on the meta row (e.g. \" / iOS, Web, Godot.\")
- Drops the empty span and the now-orphan separator; meta now reads \"iOS, Web, Godot.\"

If the intent was for there to be a second meta value (role, location, etc.), happy to revise — let me know what to put there instead.

Closes #9

## Test plan
- [ ] Load nsluke.org and verify the hero shows \"Made In New York.\" then \"iOS, Web, Godot.\" with no orphan slash

🤖 Generated with [Claude Code](https://claude.com/claude-code)