### PR TITLE
Allow MySpace music to autoplay (muted)

### DIFF
--- a/public/myspace/index.html
+++ b/public/myspace/index.html
@@ -413,7 +413,7 @@
           <iframe
             width="100%"
             height="150"
-            src="https://www.youtube.com/embed/RRKJiM9Njr8?autoplay=1&loop=1&playlist=RRKJiM9Njr8"
+            src="https://www.youtube.com/embed/RRKJiM9Njr8?autoplay=1&mute=1&loop=1&playlist=RRKJiM9Njr8"
             allow="autoplay"
             frameborder="0"
             style="border: 1px inset #333;"


### PR DESCRIPTION
## Summary
- Browsers block unmuted autoplay on cross-origin iframes; the YouTube embed never started on its own
- Add \`mute=1\` so playback begins automatically. Visitors can unmute via the YouTube controls.

The \"hit play if it doesn't start\" caption could be removed in a follow-up if we're confident the muted autoplay is enough.

Closes #10

## Test plan
- [ ] Load \`/myspace/\` in a fresh tab and confirm the YouTube embed begins playing on its own (muted)
- [ ] Click the unmute button in the iframe controls and confirm audio plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)