### PR TITLE
Make splash page copyright year self-updating

### DIFF
--- a/public/bling-my-deck/index.html
+++ b/public/bling-my-deck/index.html
@@ -246,12 +246,13 @@
   </div>
 
   <footer>
-    <div>Bling My Deck &copy; 2024.</div>
+    <div>Bling My Deck &copy; <span class="copy-year">2024</span>.</div>
     <div class="footer-links">
       <a href="https://github.com/nsluke/blingmydeck">GitHub</a>
       <a href="/">Portfolio</a>
     </div>
   </footer>
 
+  <script>document.querySelector(".copy-year").textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/public/claudius/index.html
+++ b/public/claudius/index.html
@@ -246,12 +246,13 @@
   </div>
 
   <footer>
-    <div>Claudius &copy; 2024.</div>
+    <div>Claudius &copy; <span class="copy-year">2024</span>.</div>
     <div class="footer-links">
       <a href="https://github.com/nsluke/Claudius">GitHub</a>
       <a href="/">Portfolio</a>
     </div>
   </footer>
 
+  <script>document.querySelector(".copy-year").textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/public/lazer-dragon/index.html
+++ b/public/lazer-dragon/index.html
@@ -246,12 +246,13 @@
   </div>
 
   <footer>
-    <div>The Lazer Dragon Workout Experience &copy; 2024.</div>
+    <div>The Lazer Dragon Workout Experience &copy; <span class="copy-year">2024</span>.</div>
     <div class="footer-links">
       <a href="https://github.com/nsluke/Lazer-Dragon-Workout-Experience">GitHub</a>
       <a href="/">Portfolio</a>
     </div>
   </footer>
 
+  <script>document.querySelector(".copy-year").textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/public/manadrain/index.html
+++ b/public/manadrain/index.html
@@ -246,12 +246,13 @@
   </div>
 
   <footer>
-    <div>Manadrain &copy; 2024.</div>
+    <div>Manadrain &copy; <span class="copy-year">2024</span>.</div>
     <div class="footer-links">
       <a href="https://github.com/nsluke/manadrain">GitHub</a>
       <a href="/">Portfolio</a>
     </div>
   </footer>
 
+  <script>document.querySelector(".copy-year").textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/public/mock-starket/index.html
+++ b/public/mock-starket/index.html
@@ -246,12 +246,13 @@
   </div>
 
   <footer>
-    <div>Mock Starket &copy; 2024.</div>
+    <div>Mock Starket &copy; <span class="copy-year">2024</span>.</div>
     <div class="footer-links">
       <a href="https://github.com/nsluke/Mock-Starket-iOS">GitHub</a>
       <a href="/">Portfolio</a>
     </div>
   </footer>
 
+  <script>document.querySelector(".copy-year").textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/public/planechase-bot/index.html
+++ b/public/planechase-bot/index.html
@@ -246,12 +246,13 @@
   </div>
 
   <footer>
-    <div>Planechase Bot &copy; 2024.</div>
+    <div>Planechase Bot &copy; <span class="copy-year">2024</span>.</div>
     <div class="footer-links">
       <a href="https://github.com/nsluke/Planechase-Bot">GitHub</a>
       <a href="/">Portfolio</a>
     </div>
   </footer>
 
+  <script>document.querySelector(".copy-year").textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/public/pushpush/index.html
+++ b/public/pushpush/index.html
@@ -246,12 +246,13 @@
   </div>
 
   <footer>
-    <div>PushPush &copy; 2024.</div>
+    <div>PushPush &copy; <span class="copy-year">2024</span>.</div>
     <div class="footer-links">
       <a href="https://github.com/nsluke/PushPush">GitHub</a>
       <a href="/">Portfolio</a>
     </div>
   </footer>
 
+  <script>document.querySelector(".copy-year").textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/public/treachery/index.html
+++ b/public/treachery/index.html
@@ -246,12 +246,13 @@
   </div>
 
   <footer>
-    <div>Treachery &copy; 2024.</div>
+    <div>Treachery &copy; <span class="copy-year">2024</span>.</div>
     <div class="footer-links">
       <a href="https://github.com/paintedlabs/Treachery-FrontEnd">GitHub</a>
       <a href="/">Portfolio</a>
     </div>
   </footer>
 
+  <script>document.querySelector(".copy-year").textContent = new Date().getFullYear();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- All eight splash page footers were hardcoded to \`© 2024\` and had drifted out of date
- Wrap the year in \`<span class=\"copy-year\">\` and add a one-line inline script that overwrites it with \`new Date().getFullYear()\`, matching the pattern already in \`Footer.jsx\`
- The hardcoded \`2024\` stays as a no-JS fallback

Closes #12

## Test plan
- [ ] Load any splash page (e.g. \`/treachery/\`) with JS enabled and confirm the footer shows the current year
- [ ] Disable JS and confirm the footer falls back to \`2024.\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)