### PR TITLE
Make project accordion rows keyboard-accessible

### DIFF
--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -49,6 +49,11 @@
   opacity: 0.3;
 }
 
+.project-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 /* --- Row header (original grid layout) --- */
 .project-row-header {
   display: grid;

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -96,6 +96,13 @@ function Projects() {
     setSelected(selected === i ? null : i)
   }
 
+  const handleKeyDown = (e, i) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      toggleProject(i)
+    }
+  }
+
   return (
     <section className="projects" id="projects">
       <div className="projects-header">
@@ -114,9 +121,13 @@ function Projects() {
                 hovered !== null && hovered !== i && selected === null ? 'dimmed' : '',
                 isOpen ? 'expanded' : '',
               ].filter(Boolean).join(' ')}
+              role="button"
+              tabIndex={0}
+              aria-expanded={isOpen}
               onMouseEnter={() => selected === null && setHovered(i)}
               onMouseLeave={() => setHovered(null)}
               onClick={() => toggleProject(i)}
+              onKeyDown={(e) => handleKeyDown(e, i)}
             >
               <div className="project-row-header">
                 <div className="project-index">


### PR DESCRIPTION
## Summary
- Project rows were \`<div onClick>\` only — keyboard users could not focus or expand them
- Add \`role=\"button\"\`, \`tabIndex={0}\`, and \`aria-expanded\` on the row
- Toggle on Enter and Space (preventDefault to avoid Space scrolling)
- Add a \`:focus-visible\` outline so keyboard users see the focused row

Closes #11

## Notes
The inner Details / GitHub / live links remain ordinary \`<a>\` tags and tab independently. Nesting tabbable links inside a \`role=\"button\"\` is technically not ARIA-spec-perfect but works correctly in practice — a follow-up could refactor the row to a \`<button>\` for the header only and decouple from the expanded content.

## Test plan
- [ ] Tab through nsluke.org and confirm each project row receives focus with a visible accent outline
- [ ] Press Enter or Space to expand/collapse the focused row
- [ ] Confirm Tab still moves through the inner Details / GitHub / live links inside an expanded row
- [ ] Run an accessibility scan (axe DevTools / Lighthouse) and confirm no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)