### PR TITLE
Show actual screenshots on splash pages

### DIFF
--- a/public/bling-my-deck/index.html
+++ b/public/bling-my-deck/index.html
@@ -177,11 +177,16 @@
 
     .window-content {
       flex: 1;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: var(--text-dim);
-      font-size: 14px;
+      overflow: hidden;
+      border-bottom-left-radius: 12px;
+      border-bottom-right-radius: 12px;
+    }
+
+    .window-content img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
     }
 
     footer {
@@ -240,7 +245,7 @@
         <div class="dot green"></div>
       </div>
       <div class="window-content">
-        Screenshot / Demo Content
+        <img src="/screenshots/bling-my-deck.png" alt="Bling My Deck screenshot">
       </div>
     </div>
   </div>

--- a/public/claudius/index.html
+++ b/public/claudius/index.html
@@ -177,11 +177,16 @@
 
     .window-content {
       flex: 1;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: var(--text-dim);
-      font-size: 14px;
+      overflow: hidden;
+      border-bottom-left-radius: 12px;
+      border-bottom-right-radius: 12px;
+    }
+
+    .window-content img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
     }
 
     footer {
@@ -240,7 +245,7 @@
         <div class="dot green"></div>
       </div>
       <div class="window-content">
-        Screenshot / Demo Content
+        <img src="/screenshots/claudius.png" alt="Claudius screenshot">
       </div>
     </div>
   </div>

--- a/public/lazer-dragon/index.html
+++ b/public/lazer-dragon/index.html
@@ -177,11 +177,16 @@
 
     .window-content {
       flex: 1;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: var(--text-dim);
-      font-size: 14px;
+      overflow: hidden;
+      border-bottom-left-radius: 12px;
+      border-bottom-right-radius: 12px;
+    }
+
+    .window-content img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
     }
 
     footer {
@@ -240,7 +245,7 @@
         <div class="dot green"></div>
       </div>
       <div class="window-content">
-        Screenshot / Demo Content
+        <img src="/screenshots/lazer-dragon.png" alt="The Lazer Dragon Workout Experience screenshot">
       </div>
     </div>
   </div>

--- a/public/manadrain/index.html
+++ b/public/manadrain/index.html
@@ -177,11 +177,16 @@
 
     .window-content {
       flex: 1;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: var(--text-dim);
-      font-size: 14px;
+      overflow: hidden;
+      border-bottom-left-radius: 12px;
+      border-bottom-right-radius: 12px;
+    }
+
+    .window-content img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
     }
 
     footer {
@@ -240,7 +245,7 @@
         <div class="dot green"></div>
       </div>
       <div class="window-content">
-        Screenshot / Demo Content
+        <img src="/screenshots/manadrain.png" alt="Manadrain screenshot">
       </div>
     </div>
   </div>

--- a/public/mock-starket/index.html
+++ b/public/mock-starket/index.html
@@ -177,11 +177,16 @@
 
     .window-content {
       flex: 1;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: var(--text-dim);
-      font-size: 14px;
+      overflow: hidden;
+      border-bottom-left-radius: 12px;
+      border-bottom-right-radius: 12px;
+    }
+
+    .window-content img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
     }
 
     footer {
@@ -240,7 +245,7 @@
         <div class="dot green"></div>
       </div>
       <div class="window-content">
-        Screenshot / Demo Content
+        <img src="/screenshots/mock-starket.png" alt="Mock Starket screenshot">
       </div>
     </div>
   </div>

--- a/public/planechase-bot/index.html
+++ b/public/planechase-bot/index.html
@@ -232,19 +232,6 @@
     </div>
   </section>
 
-  <div class="product-showcase">
-    <div class="placeholder-window">
-      <div class="window-header">
-        <div class="dot red"></div>
-        <div class="dot yellow"></div>
-        <div class="dot green"></div>
-      </div>
-      <div class="window-content">
-        Screenshot / Demo Content
-      </div>
-    </div>
-  </div>
-
   <footer>
     <div>Planechase Bot &copy; 2024.</div>
     <div class="footer-links">

--- a/public/pushpush/index.html
+++ b/public/pushpush/index.html
@@ -177,11 +177,16 @@
 
     .window-content {
       flex: 1;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: var(--text-dim);
-      font-size: 14px;
+      overflow: hidden;
+      border-bottom-left-radius: 12px;
+      border-bottom-right-radius: 12px;
+    }
+
+    .window-content img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
     }
 
     footer {
@@ -240,7 +245,7 @@
         <div class="dot green"></div>
       </div>
       <div class="window-content">
-        Screenshot / Demo Content
+        <img src="/screenshots/pushpush.png" alt="PushPush screenshot">
       </div>
     </div>
   </div>

--- a/public/treachery/index.html
+++ b/public/treachery/index.html
@@ -177,11 +177,16 @@
 
     .window-content {
       flex: 1;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: var(--text-dim);
-      font-size: 14px;
+      overflow: hidden;
+      border-bottom-left-radius: 12px;
+      border-bottom-right-radius: 12px;
+    }
+
+    .window-content img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
     }
 
     footer {
@@ -240,7 +245,7 @@
         <div class="dot green"></div>
       </div>
       <div class="window-content">
-        Screenshot / Demo Content
+        <img src="/screenshots/treachery.png" alt="Treachery screenshot">
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- 7 of 8 splash pages now render their corresponding image from \`/public/screenshots/\` instead of the \"Screenshot / Demo Content\" placeholder
- \`.window-content\` updated so the image fills the macOS-style frame (\`object-fit: contain\` to avoid cropping)
- Planechase Bot has no screenshot yet, so its \`.product-showcase\` block is removed rather than left as a placeholder. The (now unused) window-frame CSS rules remain in that file as harmless dead code; happy to clean those up in a follow-up if you'd like.

Closes #7

## Test plan
- [ ] Visit each of these pages and confirm the screenshot renders inside the window frame:
  - /treachery/ /lazer-dragon/ /claudius/ /manadrain/ /pushpush/ /mock-starket/ /bling-my-deck/
- [ ] Visit /planechase-bot/ and confirm no broken/empty showcase area below the hero
- [ ] Spot-check on mobile width that images don't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)