### PR TITLE
Add Manadrain Chrome listing alongside Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ React 19 + Vite, deployed to GitHub Pages via GitHub Actions.
 | Treachery | Multiplayer MTG Variant for iOS | [treachery.games](https://treachery.games) · [GitHub](https://github.com/paintedlabs/Treachery-FrontEnd) |
 | The Lazer Dragon Workout Experience | Think you can take on the Lazer Dragon? | [GitHub](https://github.com/nsluke/Lazer-Dragon-Workout-Experience) |
 | Claudius | Track your Claude usage right in your menu bar | [Download](https://github.com/nsluke/Claudius/releases) · [GitHub](https://github.com/nsluke/Claudius) |
-| Manadrain | Stash your favorite cards for later | [GitHub](https://github.com/nsluke/manadrain) |
+| Manadrain | Stash your favorite cards for later | [Chrome](https://chromewebstore.google.com/detail/manadrain-mtg-shopping-li/kiappkeljeebfeaijnooichjpajeocif) · [Firefox](https://addons.mozilla.org/en-US/firefox/addon/manadrain-mtg-shopping-list/) · [GitHub](https://github.com/nsluke/manadrain) |
 | PushPush | The first game I ever made. Aged like fine wine. | [GitHub](https://github.com/nsluke/PushPush) |
 | Bling My Deck | Find the most expensive printing of every card in your MTG deck | [blingoutmydeck.com](https://blingoutmydeck.com) · [GitHub](https://github.com/nsluke/blingmydeck) |
 

--- a/public/manadrain/index.html
+++ b/public/manadrain/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Manadrain — Portfolio</title>
-  <meta name="description" content="A Firefox browser extension that lets you save Magic: The Gathering cards to a shopping list while browsing. Quickly stash cards you want to buy later.">
+  <meta name="description" content="A browser extension for Chrome and Firefox that lets you save Magic: The Gathering cards to a shopping list while browsing. Quickly stash cards you want to buy later.">
   <style>
     :root {
       --bg: #000000;
@@ -223,16 +223,17 @@
       <div class="nav-links">
         <a href="/">Back to Portfolio</a>
         <a href="https://github.com/nsluke/manadrain">GitHub</a>
-        <a href="https://addons.mozilla.org/en-US/firefox/addon/manadrain-mtg-shopping-list/" class="btn-download-sm">Firefox Add-on</a>
+        <a href="https://chromewebstore.google.com/detail/manadrain-mtg-shopping-li/kiappkeljeebfeaijnooichjpajeocif" class="btn-download-sm">Chrome</a>
       </div>
     </div>
   </nav>
 
   <section class="hero">
     <h1>Manadrain</h1>
-    <p>A Firefox browser extension that lets you save Magic: The Gathering cards to a shopping list while browsing. Quickly stash cards you want to buy later.</p>
+    <p>A browser extension for Chrome and Firefox that lets you save Magic: The Gathering cards to a shopping list while browsing. Quickly stash cards you want to buy later.</p>
     <div class="cta-group">
-      <a href="https://addons.mozilla.org/en-US/firefox/addon/manadrain-mtg-shopping-list/" class="btn-primary">Firefox Add-on</a>
+      <a href="https://chromewebstore.google.com/detail/manadrain-mtg-shopping-li/kiappkeljeebfeaijnooichjpajeocif" class="btn-primary">Chrome</a>
+      <a href="https://addons.mozilla.org/en-US/firefox/addon/manadrain-mtg-shopping-list/" class="btn-primary">Firefox</a>
       <a href="https://github.com/nsluke/manadrain" class="btn-secondary">View on GitHub &rarr;</a>
     </div>
   </section>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -8,8 +8,7 @@ const projects = [
     description: 'Multiplayer MTG Variant for iOS',
     tech: 'Swift',
     github: 'https://github.com/paintedlabs/Treachery-FrontEnd',
-    liveUrl: 'https://treachery.games',
-    liveLabel: 'Play',
+    liveLinks: [{ url: 'https://treachery.games', label: 'Play' }],
     longDescription: 'A multiplayer Magic: The Gathering variant app for iOS that brings the Treachery format to your phone. Play with friends in real-time with role-based gameplay.',
     screenshot: '/screenshots/treachery.png', // TODO: add screenshot path e.g. '/screenshots/treachery.png'
   },
@@ -19,8 +18,7 @@ const projects = [
     description: 'Think you can take on the Lazer Dragon?',
     tech: 'Swift',
     github: 'https://github.com/nsluke/Lazer-Dragon-Workout-Experience',
-    liveUrl: 'https://testflight.apple.com/join/Uv2Xufqr',
-    liveLabel: 'TestFlight',
+    liveLinks: [{ url: 'https://testflight.apple.com/join/Uv2Xufqr', label: 'TestFlight' }],
     longDescription: 'An iOS workout app disguised as a boss battle. Complete exercises to deal damage to the Lazer Dragon — skip reps and face the consequences.',
     screenshot: '/screenshots/lazer-dragon.png',
   },
@@ -30,8 +28,7 @@ const projects = [
     description: 'Track your claude usage right in your menu bar',
     tech: 'Swift',
     github: 'https://github.com/nsluke/Claudius',
-    liveUrl: 'https://github.com/nsluke/Claudius/releases',
-    liveLabel: 'Download',
+    liveLinks: [{ url: 'https://github.com/nsluke/Claudius/releases', label: 'Download' }],
     longDescription: 'A macOS menu bar app that tracks your Claude API usage in real-time. See spend, token counts, and usage trends at a glance without leaving your workflow.',
     screenshot: '/screenshots/claudius.png',
   },
@@ -41,9 +38,11 @@ const projects = [
     description: 'Stash your favorite cards for later.',
     tech: 'TypeScript',
     github: 'https://github.com/nsluke/manadrain',
-    liveUrl: 'https://addons.mozilla.org/en-US/firefox/addon/manadrain-mtg-shopping-list/',
-    liveLabel: 'Firefox Add-on',
-    longDescription: 'A Firefox browser extension that lets you save Magic: The Gathering cards to a shopping list while browsing. Quickly stash cards you want to buy later.',
+    liveLinks: [
+      { url: 'https://chromewebstore.google.com/detail/manadrain-mtg-shopping-li/kiappkeljeebfeaijnooichjpajeocif', label: 'Chrome' },
+      { url: 'https://addons.mozilla.org/en-US/firefox/addon/manadrain-mtg-shopping-list/', label: 'Firefox' },
+    ],
+    longDescription: 'A browser extension for Chrome and Firefox that lets you save Magic: The Gathering cards to a shopping list while browsing. Quickly stash cards you want to buy later.',
     screenshot: '/screenshots/manadrain.png',
   },
   {
@@ -52,8 +51,7 @@ const projects = [
     description: 'The First game I ever made. Aged like fine wine.',
     tech: 'Objective-C',
     github: 'https://github.com/nsluke/PushPush',
-    liveUrl: 'https://testflight.apple.com/join/wRBak44b',
-    liveLabel: 'TestFlight',
+    liveLinks: [{ url: 'https://testflight.apple.com/join/wRBak44b', label: 'TestFlight' }],
     longDescription: 'The very first iOS game I ever built. A simple but addictive pushing game written in Objective-C. Still holds up after all these years.',
     screenshot: '/screenshots/pushpush.png',
   },
@@ -63,8 +61,7 @@ const projects = [
     description: 'Find the most expensive printing of every card in your MTG deck',
     tech: 'TypeScript',
     github: 'https://github.com/nsluke/blingmydeck',
-    liveUrl: 'https://blingoutmydeck.com',
-    liveLabel: 'Visit',
+    liveLinks: [{ url: 'https://blingoutmydeck.com', label: 'Visit' }],
     longDescription: 'A web tool that finds the most expensive printing of every card in your Magic: The Gathering deck. Paste your decklist and see just how much it would cost to fully bling it out.',
     screenshot: '/screenshots/bling-my-deck.png',
   },
@@ -94,6 +91,7 @@ function Projects() {
       <div className="projects-list">
         {projects.map((project, i) => {
           const isOpen = selected === i
+          const liveLinks = project.liveLinks ?? []
 
           return (
             <div
@@ -137,16 +135,19 @@ function Projects() {
                   >
                     GitHub
                   </a>
-                  {project.liveUrl ? (
-                    <a
-                      href={project.liveUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="project-link project-link-live"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {project.liveLabel} -&gt;
-                    </a>
+                  {liveLinks.length > 0 ? (
+                    liveLinks.map((link) => (
+                      <a
+                        key={link.url}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="project-link project-link-live"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {link.label} -&gt;
+                      </a>
+                    ))
                   ) : (
                     <span className="project-link project-link-soon">Coming Soon</span>
                   )}


### PR DESCRIPTION
## Summary
Manadrain is on the Chrome Web Store too — surfacing both stores everywhere it's listed.

- Refactor \`Projects.jsx\` from single \`liveUrl/liveLabel\` to a generic \`liveLinks: [{url, label}]\` array. Other projects still render one button through the same code path; Manadrain now renders two.
- Update the Manadrain splash page (\`/public/manadrain/\`):
  - Nav download button: Firefox → Chrome (single button to avoid crowding nav)
  - Hero CTA group: Chrome (primary) + Firefox (primary) + GitHub (secondary)
  - Meta description and hero blurb updated from \"A Firefox browser extension\" → \"A browser extension for Chrome and Firefox\"
- Update README's Manadrain row to list both stores

## Note on stacking
This branches off main without PR #20 (Planechase Bot removal). The two PRs touch different projects in \`Projects.jsx\` so they should merge cleanly in either order.

## Test plan
- [ ] Home page accordion: expand Manadrain, confirm both \"Chrome →\" and \"Firefox →\" buttons render
- [ ] Click each button, confirms it goes to the correct store
- [ ] Visit \`/manadrain/\` splash page and confirm both store CTAs in the hero, and the Chrome download button in the nav
- [ ] Single-link projects (Treachery, Lazer Dragon, Claudius, PushPush, Bling My Deck) still render one live-link button as before
- [ ] Planechase Bot still shows \"Coming Soon\" placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)